### PR TITLE
Add option to choose port from command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@ This is the source code for my post on [Building a Blockchain](https://medium.co
 
 1. Make sure [Python 3.6+](https://www.python.org/downloads/) is installed
 1. Install requirements: `$ pip install -r requirements.txt`
-1. Run the server: `$ python blockchain.py`
+1. Run the server:
+    * `$ python blockchain.py` 
+    * `$ python blockchain.py -p 5001`
+    * `$ python blockchain.py --port 5002`
 
 ## Contributing
 

--- a/blockchain.py
+++ b/blockchain.py
@@ -279,4 +279,11 @@ def consensus():
 
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5000)
+    from argparse import ArgumentParser
+
+    parser = ArgumentParser()
+    parser.add_argument('-p', '--port', default=5000, type=int, help='port to listen on')
+    args = parser.parse_args()
+    port = args.port
+
+    app.run(host='0.0.0.0', port=port)


### PR DESCRIPTION
In your tutorial you set up a second node on port 5001 to demonstrate the consensus algorithm. However the port is hard-coded in which makes starting additional nodes on the same machine difficult. I propose a command line option to specify the port, otherwise defaulting to 5000. The PR gives the following usage:

```
python blockchain.py # defaults to 5000
python blockchain.py -p 5001
python blockchain.py --port 5002
```
