### PR TITLE
Modified valid_proof and proof_of_work to include the hash of last block

### DIFF
--- a/blockchain.py
+++ b/blockchain.py
@@ -159,7 +159,7 @@ class Blockchain(object):
         """
 
         last_proof = last_block['proof']
-        last_hash = last_block['previous_hash']
+        last_hash = self.hash(last_block)
 
         proof = 0
         while self.valid_proof(last_proof, proof, last_hash) is False:

--- a/blockchain.py
+++ b/blockchain.py
@@ -49,7 +49,7 @@ class Blockchain(object):
                 return False
 
             # Check that the Proof of Work is correct
-            if not self.valid_proof(last_block['proof'], block['proof']):
+            if not self.valid_proof(last_block['proof'], block['proof'], last_block['previous_hash']):
                 return False
 
             last_block = block
@@ -148,33 +148,37 @@ class Blockchain(object):
         block_string = json.dumps(block, sort_keys=True).encode()
         return hashlib.sha256(block_string).hexdigest()
 
-    def proof_of_work(self, last_proof):
+    def proof_of_work(self, last_block):
         """
         Simple Proof of Work Algorithm:
-         - Find a number p' such that hash(pp') contains leading 4 zeroes, where p is the previous p'
-         - p is the previous proof, and p' is the new proof
+         - Find a number p' such that hash(pp'h) contains leading 4 zeroes, where p is the previous p'
+         - p is the previous proof, p' is the new proof, and h is the hash of the last block
 
-        :param last_proof: <int>
+        :param last_block: <dict> last Block
         :return: <int>
         """
 
+        last_proof = last_block['proof']
+        last_hash = last_block['previous_hash']
+
         proof = 0
-        while self.valid_proof(last_proof, proof) is False:
+        while self.valid_proof(last_proof, proof, last_hash) is False:
             proof += 1
 
         return proof
 
     @staticmethod
-    def valid_proof(last_proof, proof):
+    def valid_proof(last_proof, proof, last_hash):
         """
         Validates the Proof
 
         :param last_proof: <int> Previous Proof
         :param proof: <int> Current Proof
+        :param last_hash: <str> The hash of the Previous Block
         :return: <bool> True if correct, False if not.
         """
 
-        guess = f'{last_proof}{proof}'.encode()
+        guess = f'{last_proof}{proof}{last_hash}'.encode()
         guess_hash = hashlib.sha256(guess).hexdigest()
         return guess_hash[:4] == "0000"
 
@@ -193,8 +197,7 @@ blockchain = Blockchain()
 def mine():
     # We run the proof of work algorithm to get the next proof...
     last_block = blockchain.last_block
-    last_proof = last_block['proof']
-    proof = blockchain.proof_of_work(last_proof)
+    proof = blockchain.proof_of_work(last_block)
 
     # We must receive a reward for finding the proof.
     # The sender is "0" to signify that this node has mined a new coin.


### PR DESCRIPTION
In response to the Issue that [proofs don't depend on the previous hash](https://github.com/dvf/blockchain/issues/10), `valid_proof` and `proof_of_work` methods were modified to include the previous hash. 