### PR TITLE
Add tests and coverage

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,6 +4,9 @@ verify_ssl = true
 name = "pypi"
 
 [dev-packages]
+pytest = "*"
+"pytest-coverage" = "*"
+
 
 [requires]
 python_version = "3.6"
@@ -12,4 +15,3 @@ python_version = "3.6"
 
 flask = "==0.12.2"
 requests = "==2.18.4"
-

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,20 +1,20 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "45af71184b5b013f58a8601f7f87c9f0b882afe19f197ce45d6d08e46d615159"
+            "sha256": "5b0014a32283bf1d401562458451166c88219a76c59d2e58cc20903785f5e7ed"
         },
         "host-environment-markers": {
             "implementation_name": "cpython",
-            "implementation_version": "3.6.2",
+            "implementation_version": "3.6.3",
             "os_name": "posix",
             "platform_machine": "x86_64",
             "platform_python_implementation": "CPython",
-            "platform_release": "4.10.0-35-generic",
-            "platform_system": "Linux",
-            "platform_version": "#39~16.04.1-Ubuntu SMP Wed Sep 13 09:02:42 UTC 2017",
-            "python_full_version": "3.6.2",
+            "platform_release": "16.7.0",
+            "platform_system": "Darwin",
+            "platform_version": "Darwin Kernel Version 16.7.0: Thu Jun 15 17:36:27 PDT 2017; root:xnu-3789.70.16~2/RELEASE_X86_64",
+            "python_full_version": "3.6.3",
             "python_version": "3.6",
-            "sys_platform": "linux"
+            "sys_platform": "darwin"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -105,5 +105,90 @@
             "version": "==0.12.2"
         }
     },
-    "develop": {}
+    "develop": {
+        "coverage": {
+            "hashes": [
+                "sha256:c1456f66c536010cf9e4633a8853a9153e8fd588393695295afd4d0fc16c1d74",
+                "sha256:97a7ec51cdde3a386e390b159b20f247ccb478084d925c75f1faa3d26c01335e",
+                "sha256:83e955b975666b5a07d217135e7797857ce844eb340a99e46cc25525120417c4",
+                "sha256:483ed14080c5301048128bb027b77978c632dd9e92e3ecb09b7e28f5b92abfcf",
+                "sha256:ef574ab9640bcfa2f3c671831faf03f65788945fdf8efa4d4a1fffc034838e2a",
+                "sha256:c5a205b4da3c624f5119dc4d84240789b5906bb8468902ec22dcc4aad8aa4638",
+                "sha256:5dea90ed140e7fa9bc00463313f9bc4a6e6aff297b4969615e7a688615c4c4d2",
+                "sha256:f9e83b39d29c2815a38e4118d776b482d4082b5bf9c9147fbc99a3f83abe480a",
+                "sha256:700040c354f0230287906b1276635552a3def4b646e0145555bc9e2e5da9e365",
+                "sha256:7f1eacae700c66c3d7362a433b228599c9d94a5a3a52613dddd9474e04deb6bc",
+                "sha256:13ef9f799c8fb45c446a239df68034de3a6f3de274881b088bebd7f5661f79f8",
+                "sha256:dfb011587e2b7299112f08a2a60d2601706aac9abde37aa1177ea825adaed923",
+                "sha256:381be5d31d3f0d912334cf2c159bc7bea6bfe6b0e3df6061a3bf2bf88359b1f6",
+                "sha256:83a477ac4f55a6ef59552683a0544d47b68a85ce6a80fd0ca6b3dc767f6495fb",
+                "sha256:dfd35f1979da31bcabbe27bcf78d4284d69870731874af629082590023a77336",
+                "sha256:9681efc2d310cfc53863cc6f63e88ebe7a48124550fa822147996cb09390b6ab",
+                "sha256:53770b20ac5b4a12e99229d4bae57af0945be87cc257fce6c6c7571a39f0c5d4",
+                "sha256:8801880d32f11b6df11c32a961e186774b4634ae39d7c43235f5a24368a85f07",
+                "sha256:16db2c69a1acbcb3c13211e9f954e22b22a729909d81f983b6b9badacc466eda",
+                "sha256:ef43a06a960b46c73c018704051e023ee6082030f145841ffafc8728039d5a88",
+                "sha256:c3e2736664a6074fc9bd54fb643f5af0fc60bfedb2963b3d3f98c7450335e34c",
+                "sha256:17709e22e4c9f5412ba90f446fb13b245cc20bf4a60377021bbff6c0f1f63e7c",
+                "sha256:a2f7106d1167825c4115794c2ba57cc3b15feb6183db5328fa66f94c12902d8b",
+                "sha256:2a08e978f402696c6956eee9d1b7e95d3ad042959b71bafe1f3e4557cbd6e0ac",
+                "sha256:57f510bb16efaec0b6f371b64a8000c62e7e3b3e48e8b0a5745ade078d849814",
+                "sha256:0f1883eab9c19aa243f51308751b8a2a547b9b817b721cc0ecf3efb99fafbea7",
+                "sha256:e00fe141e22ce6e9395aa24d862039eb180c6b7e89df0bbaf9765e9aebe560a9",
+                "sha256:ec596e4401553caa6dd2e3349ce47f9ef82c1f1bcba5d8ac3342724f0df8d6ff",
+                "sha256:c820a533a943ebc860acc0ce6a00dd36e0fdf2c6f619ff8225755169428c5fa2",
+                "sha256:b7f7283eb7badd2b8a9c6a9d6eeca200a0a24db6be79baee2c11398f978edcaa",
+                "sha256:a5ed27ad3e8420b2d6b625dcbd3e59488c14ccc06030167bcf14ffb0f4189b77",
+                "sha256:d7b70b7b4eb14d0753d33253fe4f121ca99102612e2719f0993607deb30c6f33",
+                "sha256:4047dc83773869701bde934fb3c4792648eda7c0e008a77a0aec64157d246801",
+                "sha256:7a9c44400ee0f3b4546066e0710e1250fd75831adc02ab99dda176ad8726f424",
+                "sha256:0f649e68db74b1b5b8ca4161d08eb2b8fa8ae11af1ebfb80e80e112eb0ef5300",
+                "sha256:52964fae0fafef8bd283ad8e9a9665205a9fdf912535434defc0ec3def1da26b",
+                "sha256:36aa6c8db83bc27346ddcd8c2a60846a7178ecd702672689d3ea1828eb1a4d11",
+                "sha256:9824e15b387d331c0fc0fef905a539ab69784368a1d6ac3db864b4182e520948",
+                "sha256:4a678e1b9619a29c51301af61ab84122e2f8cc7a0a6b40854b808ac6be604300",
+                "sha256:8bb7c8dca54109b61013bc4114d96effbf10dea136722c586bce3a5d9fc4e730",
+                "sha256:1a41d621aa9b6ab6457b557a754d50aaff0813fad3453434de075496fca8a183",
+                "sha256:0fa423599fc3d9e18177f913552cdb34a8d9ad33efcf52a98c9d4b644edb42c5",
+                "sha256:e61a4ba0b2686040cb4828297c7e37bcaf3a1a1c0bc0dbe46cc789dde51a80fa",
+                "sha256:ce9ef0fc99d11d418662e36fd8de6d71b19ec87c2eab961a117cc9d087576e72"
+            ],
+            "version": "==4.4.1"
+        },
+        "py": {
+            "hashes": [
+                "sha256:2ccb79b01769d99115aa600d7eed99f524bf752bba8f041dc1c184853514655a",
+                "sha256:0f2d585d22050e90c7d293b6451c83db097df77871974d90efd5a30dc12fcde3"
+            ],
+            "version": "==1.4.34"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:81a25f36a97da3313e1125fce9e7bbbba565bc7fec3c5beb14c262ddab238ac1",
+                "sha256:27fa6617efc2869d3e969a3e75ec060375bfb28831ade8b5cdd68da3a741dc3c"
+            ],
+            "version": "==3.2.3"
+        },
+        "pytest-cov": {
+            "hashes": [
+                "sha256:890fe5565400902b0c78b5357004aab1c814115894f4f21370e2433256a3eeec",
+                "sha256:03aa752cf11db41d281ea1d807d954c4eda35cfa1b21d6971966cc041bbf6e2d"
+            ],
+            "version": "==2.5.1"
+        },
+        "pytest-cover": {
+            "hashes": [
+                "sha256:578249955eb3b5f3991209df6e532bb770b647743b7392d3d97698dc02f39ebb",
+                "sha256:5bdb6c1cc3dd75583bb7bc2c57f5e1034a1bfcb79d27c71aceb0b16af981dbf4"
+            ],
+            "version": "==3.0.0"
+        },
+        "pytest-coverage": {
+            "hashes": [
+                "sha256:dedd084c5e74d8e669355325916dc011539b190355021b037242514dee546368",
+                "sha256:db6af2cbd7e458c7c9fd2b4207cee75258243c8a81cad31a7ee8cfad5be93c05"
+            ],
+            "version": "==0.0"
+        }
+    }
 }

--- a/README.md
+++ b/README.md
@@ -53,7 +53,18 @@ $ docker run --rm -p 82:5000 blockchain
 $ docker run --rm -p 83:5000 blockchain
 ```
 
+## Running Tests
+
+```
+$ pytest tests/
+```
+
+With coverage report (html report for example):
+
+```
+$ pytest --cov=blockchain --cov-report html tests/
+```
+
 ## Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request.
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[aliases]
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,16 @@
+from setuptools import setup
+
+setup(
+    name='blockchain',
+    include_package_data=True,
+    install_requires=[
+        'flask',
+        'requests',
+    ],
+    setup_requires=[
+        'pytest-runner',
+    ],
+    tests_require=[
+        'pytest',
+    ],
+)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+import pytest
+import blockchain
+
+
+@pytest.fixture(scope='function')
+def app():
+    """Define the app fixture that has a new blockchain in every function scope."""
+    _app = blockchain.app
+    blockchain.blockchain = blockchain.Blockchain()
+    yield _app
+    
+
+@pytest.fixture(scope='function')
+def client(app):
+    """A Flask test client. An instance of :class:`flask.testing.TestClient`
+    by default.
+    """
+    with app.test_client() as client:
+        yield client

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,92 @@
+from blockchain import app, Blockchain, node_identifier
+import json
+
+
+def test_get_genesis_chain(client):
+    """Test get the genesis of chain."""
+    rv = client.get('/chain')
+    data = json.loads(rv.data)
+    assert rv.status_code == 200
+    assert 'chain' in data
+    assert 'length' in data
+    assert data['length'] == 1
+
+
+def test_first_block_mined(client):
+    """Test mining the first block."""
+    rv = client.get('/mine')
+    data = json.loads(rv.data)
+    assert rv.status_code == 200
+    assert 'message' in data
+    assert 'index' in data
+    assert 'transactions' in data
+    assert 'proof' in data
+    assert 'previous_hash' in data
+    assert data['index'] == 2
+
+
+def test_mining_blocks_increases_index(client):
+    """Test mining blocks increases the index."""
+    rv = client.get('/mine')
+    data_first = json.loads(rv.data)
+    rv = client.get('/mine')
+    data_second = json.loads(rv.data)
+    assert data_first['index'] == 2
+    assert data_second['index'] == 3
+
+
+def test_mining_blocks_rewards_miner(client):
+    """Test mining blocks gives a fix reward to the miner - current node."""
+    for _ in range(3):
+        rv = client.get('/mine')
+        data = json.loads(rv.data)
+        assert len(data['transactions']) == 1
+        last_transaction = data['transactions'][-1]
+        assert last_transaction['sender'] == '0'
+        assert last_transaction['recipient'] == node_identifier
+        assert last_transaction['amount'] == 1
+
+
+def test_add_new_transactions_in_one_block(client):
+    """Test creating transactions in the next block."""
+    for _ in range(3):
+        rv = client.post('/transactions/new', data=json.dumps({
+            'sender': 'X',
+            'recipient': 'Y',
+            'amount': 100.0
+        }), content_type='application/json')
+        assert rv.status_code == 201
+        data = json.loads(rv.data)
+        assert 'message' in data
+        assert 'Block 2' in data['message']
+
+
+def test_add_new_transactions_in_more_blocks(client):
+    """Test creating one transaction in each of the next few blocks."""
+    for i in range(1, 4):
+        # New transaction
+        rv = client.post('/transactions/new', data=json.dumps({
+            'sender': 'X',
+            'recipient': 'Y',
+            'amount': 100.0
+        }), content_type='application/json')
+        assert rv.status_code == 201
+        data = json.loads(rv.data)
+        assert 'message' in data
+        assert f'Block {i + 1}' in data['message']
+
+        # New block
+        rv = client.get('/mine')
+        assert rv.status_code == 200
+        data = json.loads(rv.data)
+        assert len(data['transactions']) == 2  # 1 for transaction, 1 for reward
+    
+
+def test_register_nodes(client):
+    """Test registering other nodes."""
+    pass
+
+
+def test_resolving_conflicts_between_nodes(client):
+    """Test resolving conflicts with other registered nodes."""
+    pass


### PR DESCRIPTION
I'd like to use the PR to start the conversation for #4 

This adds dependencies of: pytest and pytest-coverage for the dev environment. I think the benefit of using pytest over unittest is that writing tests in pytest is more concise.

What I've done so far is to test routes - `/mine`, `/transactions/new`, `/chain`. And the current coverage is at 55%.