### PR TITLE
Fix of type errors

### DIFF
--- a/blockchain.py
+++ b/blockchain.py
@@ -132,7 +132,7 @@ class Blockchain:
         return self.last_block['index'] + 1
 
     @property
-    def last_block(self) -> Dict[str: Any]:
+    def last_block(self) -> Dict[str, Any]:
         return self.chain[-1]
 
     @staticmethod


### PR DESCRIPTION
Traceback (most recent call last):
  File "blockchain.py", line 12, in <module>
    class Blockchain:
  File "blockchain.py", line 135, in Blockchain
    def last_block(self) -> Dict[str: Any]:
  File "/usr/local/lib/python3.6/typing.py", line 682, in inner
    return func(*args, **kwds)
  File "/usr/local/lib/python3.6/typing.py", line 1106, in __getitem__
    params = tuple(_type_check(p, msg) for p in params)
  File "/usr/local/lib/python3.6/typing.py", line 1106, in <genexpr>
    params = tuple(_type_check(p, msg) for p in params)
  File "/usr/local/lib/python3.6/typing.py", line 374, in _type_check
    raise TypeError(msg + " Got %.100r." % (arg,))
TypeError: Parameters to generic types must be types. Got slice(<class 'str'>, typing.Any, None).