### PR TITLE
Build Dockerfile using local code instead of pulling the GitHub repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,9 @@ WORKDIR /app
 
 ENV BUILD_LIST git
 
+COPY blockchain.py Pipfile /app/
+
 RUN apk add --update $BUILD_LIST \
-    && git clone https://github.com/dvf/blockchain.git /app \
     && pip install pipenv \
     && pipenv --python=python3.6 \
     && pipenv install \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 ENV BUILD_LIST git
 
-COPY blockchain.py Pipfile /app/
+COPY Pipfile /app
 
 RUN apk add --update $BUILD_LIST \
     && pip install pipenv \
@@ -12,6 +12,8 @@ RUN apk add --update $BUILD_LIST \
     && pipenv install \
     && apk del $BUILD_LIST \
     && rm -rf /var/cache/apk/*
+
+COPY blockchain.py /app
 
 EXPOSE 5000
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,35 @@ $ docker run --rm -p 82:5000 blockchain
 $ docker run --rm -p 83:5000 blockchain
 ```
 
+## End-to-End Tests
+
+Rather than testing the blockchain manually by making HTTP calls using CURL or Postman like in the blog post, end-to-end tests can also be done automated using [this Python script](https://github.com/floscha/blockchain-end2end-test/blob/master/end2end_test.py).
+In addition to the Python implementation, the script should also work for all other languages as long as they follow the same API and provide a Docker image.
+
+To run the tests, simply following these steps:
+
+1. Make sure the docker image has been built as described in the previous section.
+
+2. Clone the test script from its repository and navigate to the folder:
+
+```
+$ git clone https://github.com/floscha/blockchain-end2end-test
+$ cd blockchain-end2end-test
+```
+3. Install the required dependencies:
+
+```
+$ pip install -r requirements.txt
+```
+
+4. Run the test script as follows:
+
+```
+$ python end2end_test.py --nodes 10 --tasks clean setup connect sync-test
+```
+
+More details on how the script works can be found [here](https://github.com/floscha/blockchain-end2end-test/blob/master/README.md).
+
 ## Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request.

--- a/blockchain.py
+++ b/blockchain.py
@@ -26,7 +26,14 @@ class Blockchain:
         """
 
         parsed_url = urlparse(address)
-        self.nodes.add(parsed_url.netloc)
+        if parsed_url.netloc:
+            self.nodes.add(parsed_url.netloc)
+        elif parsed_url.path:
+            # Accepts an URL without scheme like '192.168.0.5:5000'.
+            self.nodes.add(parsed_url.path)
+        else:
+            raise ValueError('Invalid URL')
+
 
     def valid_chain(self, chain: List[Dict[str, Any]]) -> bool:
         """
@@ -132,7 +139,7 @@ class Blockchain:
         return self.last_block['index'] + 1
 
     @property
-    def last_block(self) -> Dict[str: Any]:
+    def last_block(self) -> Dict[str, Any]:
         return self.chain[-1]
 
     @staticmethod
@@ -201,7 +208,7 @@ def mine():
     )
 
     # Forge the new Block by adding it to the chain
-    block = blockchain.new_block(proof)
+    block = blockchain.new_block(proof, [])
 
     response = {
         'message': "New Block Forged",


### PR DESCRIPTION
Changes the Dockerfile to use the local code instead of pulling the latest version from GitHub. This is mainly needed to create containers that take into account modifications made locally. In case no local changes have been made, it works precisely as the current version.

I would argue that this kind of Dockerfile makes more sense. If the idea was to simply run a Docker container without the need to clone the repository first, then such an image should rather be published to https://hub.docker.com/ I guess.