### PR TITLE
Add end-to-end tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,35 @@ $ docker run --rm -p 82:5000 blockchain
 $ docker run --rm -p 83:5000 blockchain
 ```
 
+## End-to-End Tests
+
+Rather than testing the blockchain manually by making HTTP calls using CURL or Postman like in the blog post, end-to-end tests can also be done automated using [this Python script](https://github.com/floscha/blockchain-end2end-test/blob/master/end2end_test.py).
+In addition to the Python implementation, the script should also work for all other languages as long as they follow the same API and provide a Docker image.
+
+To run the tests, simply following these steps:
+
+1. Make sure the docker image has been built as described in the previous section.
+
+2. Clone the test script from its repository and navigate to the folder:
+
+```
+$ git clone https://github.com/floscha/blockchain-end2end-test
+$ cd blockchain-end2end-test
+```
+3. Install the required dependencies:
+
+```
+$ pip install -r requirements.txt
+```
+
+4. Run the test script as follows:
+
+```
+$ python end2end_test.py --nodes 10 --tasks clean setup connect sync-test
+```
+
+More details on how the script works can be found [here](https://github.com/floscha/blockchain-end2end-test/blob/master/README.md).
+
 ## Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request.


### PR DESCRIPTION
Adds an end-to-end test script partially solving Issue #4. Rather than testing functionality on a unit level, it deploys several blockchain nodes in order to test if they function as expected in a real environment.

The script provides several tasks that can be run individually or in sequence. It is also easy to add more tasks if additional functionality is to be tested.

Instead of adding the script to this repository, I created a new repository with the idea that the script could also be applied to other blockchain implementations than this one.