### PR TITLE
fix the bug in valid_proof function

### DIFF
--- a/blockchain.py
+++ b/blockchain.py
@@ -55,7 +55,7 @@ class Blockchain:
                 return False
 
             # Check that the Proof of Work is correct
-            if not self.valid_proof(last_block['proof'], block['proof'], last_block['previous_hash']):
+            if not self.valid_proof(last_block['proof'], block['proof'], block['previous_hash']):
                 return False
 
             last_block = block


### PR DESCRIPTION
In the line 58 in the file blockchain.py of current version, the last params shoud be block['previous_hash'].

Now It's last_block['previous_hash], it won't give the right hash return when you run 'nodes/resolve' on a block node.

F.Y.I