### PR TITLE
Added content type message to prevent 'NoneType' exception when content type not set in POST requests

### DIFF
--- a/blockchain.py
+++ b/blockchain.py
@@ -231,6 +231,8 @@ def mine():
 @app.route('/transactions/new', methods=['POST'])
 def new_transaction():
     values = request.get_json()
+    if values is None:
+        return 'Content Type must be application/json', 400
 
     # Check that the required fields are in the POST'ed data
     required = ['sender', 'recipient', 'amount']
@@ -256,6 +258,8 @@ def full_chain():
 @app.route('/nodes/register', methods=['POST'])
 def register_nodes():
     values = request.get_json()
+    if values is None:
+        return 'Content Type must be application/json', 400
 
     nodes = values.get('nodes')
     if nodes is None:


### PR DESCRIPTION
I got 'NoneType' exceptions when following the tutorial because I'd forgotten to set the content type in the request. I'm sure I won't be the only one to do this, so have added a None check after extracting the json values from the body.