### PR TITLE
fixed resolve conflict length bug

### DIFF
--- a/blockchain.py
+++ b/blockchain.py
@@ -83,8 +83,8 @@ class Blockchain:
             response = requests.get(f'http://{node}/chain')
 
             if response.status_code == 200:
-                length = response.json()['length']
                 chain = response.json()['chain']
+                length = len(chain)
 
                 # Check if the length is longer and the chain is valid
                 if length > max_length and self.valid_chain(chain):


### PR DESCRIPTION
It is possible to run a modified client and return a fake length e.g. `99999999` and replace the current longer chain with a shorter one.