### PR TITLE
Pin werkzeug version to prevent AttributeError: 'Request' object has no attribute 'is_xhr'

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,4 +12,4 @@ python_version = "3.6"
 
 flask = "==0.12.2"
 requests = "==2.18.4"
-
+werkzeug = "==0.12.2"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 flask==0.12.2
 requests==2.18.4
+werkzeug==0.12.2


### PR DESCRIPTION
Originated from [this issue](https://github.com/pallets/flask/issues/3869) in Flask. 

> The request.is_xhr property was deprecated since Werkzeug 0.13 and removed in Werkzeug 1.0.0. You will get this error when using Flask <= 0.12.4 and Werkzeug >=1.0.0 because Flask uses this property in the source before the 1.0.0 version.

This PR set the version of Werkzeug to 0.12.2 (the initial version in this project).