### PR TITLE
ci: add Python lint + coverage workflow

### DIFF
--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -1,0 +1,37 @@
+name: Python CI + Coverage
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    branches: [master, main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install pytest pytest-cov flake8
+
+      - name: Lint
+        run: |
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          flake8 . --count --exit-zero --max-line-length=127 --statistics
+
+      - name: Run tests with coverage (reporting-only gate)
+        run: |
+          pytest -q --cov=. --cov-report=term-missing --cov-report=xml --cov-fail-under=0
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: coverage.xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-alpine
+FROM python:3.13.0b4-alpine
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13.0b4-alpine
+FROM python:3.14.0a1-alpine
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14.0rc2-alpine
+FROM python:3.14.0-alpine
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14.0a1-alpine
+FROM python:3.14.0rc2-alpine
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14.0-alpine
+FROM python:3.14.3-alpine
 
 WORKDIR /app
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 flask==0.12.2
 requests==2.18.4
+werkzeug>=3.0.6 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 flask==0.12.2
-requests==2.18.4
+requests==2.32.4
 werkzeug>=3.0.6 # not directly required, pinned by Snyk to avoid a vulnerability
 urllib3>=2.5.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 flask==0.12.2
 requests==2.18.4
 werkzeug>=3.0.6 # not directly required, pinned by Snyk to avoid a vulnerability
+urllib3>=2.5.0 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
## Summary\n- add GitHub Actions workflow for Python CI on push/PR\n- run flake8 lint checks\n- run pytest with coverage XML output\n- upload coverage artifact for baseline reporting\n\n## Coverage gate\n- reporting-only () to establish baseline before enabling strict thresholds